### PR TITLE
添加人物素材预处理脚本与资产目录并更新 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@
 - `script.js`：处理头像点击的交互逻辑。
 
 > 页面中引用的图片均来源于互联网公开资源，仅作学习演示使用。
+
+
+## 角色素材（透明 PNG）预处理
+
+已新增素材处理脚本，可将原始剧照批量转换为统一尺寸、透明背景 PNG。
+
+```bash
+python scripts/prepare_character_assets.py --size 768
+```
+
+详细说明见 `assets/README.md`。

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,71 @@
+# JRPG 对话素材准备
+
+我已把你指定的 6 个角色整理成统一的处理流程：
+
+- 毛猛达
+- 陈国庆
+- 姚祺儿
+- 李九松
+- 嫩娘
+- 朱桢
+
+## 目录说明
+
+- `assets/raw/`：放原始剧照（建议每个角色放 2~5 张备选）。
+- `assets/portraits/`：导出的透明背景、统一尺寸 PNG。
+- `assets/source_log.csv`：记录素材来源与授权说明，便于后续管理。
+
+## 推荐命名
+
+把原图命名为“人物名_序号”，例如：
+
+- `毛猛达_01.jpg`
+- `陈国庆_01.jpg`
+- `姚祺儿_01.jpg`
+- `李九松_01.jpg`
+- `嫩娘_01.jpg`
+- `朱桢_01.jpg`
+
+## 批量处理命令
+
+先安装依赖：
+
+```bash
+pip install pillow rembg onnxruntime
+# 若只做尺寸统一可不装 rembg
+```
+
+执行处理：
+
+```bash
+python scripts/prepare_character_assets.py --size 768
+```
+
+处理完成后，会在 `assets/portraits/` 生成以下文件：
+
+- `mao_mengda.png`
+- `chen_guoqing.png`
+- `yao_qier.png`
+- `li_jiusong.png`
+- `nen_niang.png`
+- `zhu_zhen.png`
+
+## 来源记录
+
+请把每张图的来源 URL、截图时间、使用限制记录到 `assets/source_log.csv`。
+
+> 提醒：剧照通常受版权保护。建议仅用于学习/原型演示，正式发布前请确认授权。
+
+
+## rembg 缺失时的行为
+
+若未安装 `rembg`，脚本不会报错退出，而是自动降级为：
+
+- 保留原图内容（不抠透明背景）
+- 仍会统一尺寸并导出 PNG
+
+可显式关闭抠图：
+
+```bash
+python scripts/prepare_character_assets.py --size 768 --disable-rembg
+```

--- a/assets/source_log.csv
+++ b/assets/source_log.csv
@@ -1,0 +1,7 @@
+character,file_name,source_url,captured_at,license_or_note
+毛猛达,,, ,
+陈国庆,,, ,
+姚祺儿,,, ,
+李九松,,, ,
+嫩娘,,, ,
+朱桢,,, ,

--- a/scripts/prepare_character_assets.py
+++ b/scripts/prepare_character_assets.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""将人物剧照统一处理为透明背景的等尺寸 PNG。
+
+用法：
+  python scripts/prepare_character_assets.py --size 768
+
+默认从 assets/raw 读取图片，并输出到 assets/portraits。
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+import importlib
+
+
+
+SUPPORTED_EXTS = {".jpg", ".jpeg", ".png", ".webp"}
+
+
+@dataclass(frozen=True)
+class Character:
+    name: str
+    slug: str
+
+
+CHARACTERS: tuple[Character, ...] = (
+    Character("毛猛达", "mao_mengda"),
+    Character("陈国庆", "chen_guoqing"),
+    Character("姚祺儿", "yao_qier"),
+    Character("李九松", "li_jiusong"),
+    Character("嫩娘", "nen_niang"),
+    Character("朱桢", "zhu_zhen"),
+)
+
+
+def find_source_image(raw_dir: Path, name: str) -> Path | None:
+    candidates: list[Path] = []
+    for path in raw_dir.iterdir():
+        if path.suffix.lower() in SUPPORTED_EXTS and path.is_file() and path.stem.startswith(name):
+            candidates.append(path)
+    if not candidates:
+        return None
+    candidates.sort(key=lambda p: p.name)
+    return candidates[0]
+
+
+def iter_existing_sources(raw_dir: Path) -> Iterable[tuple[Character, Path]]:
+    for character in CHARACTERS:
+        source = find_source_image(raw_dir, character.name)
+        if source is None:
+            print(f"[SKIP] 未找到原图：{character.name}（请放到 {raw_dir}，文件名以人物名开头）")
+            continue
+        yield character, source
+
+
+def load_pillow_image_module():
+    module = importlib.import_module("PIL.Image")
+    return module
+
+
+def load_rembg_remove():
+    module = importlib.import_module("rembg")
+    return module.remove
+
+
+def remove_background(image_path: Path, remove_fn, image_module):
+    with image_module.open(image_path) as src:
+        rgba = src.convert("RGBA")
+        cutout = remove_fn(rgba)
+    if not isinstance(cutout, image_module.Image):
+        from io import BytesIO
+
+        cutout = image_module.open(BytesIO(cutout)).convert("RGBA")
+    return cutout
+
+
+def crop_by_alpha(img):
+    alpha = img.getchannel("A")
+    bbox = alpha.getbbox()
+    if bbox is None:
+        return img
+    return img.crop(bbox)
+
+
+def place_on_square(img, size: int, image_module):
+    img = img.copy()
+    img.thumbnail((size, size), image_module.Resampling.LANCZOS)
+
+    canvas = image_module.new("RGBA", (size, size), (0, 0, 0, 0))
+    offset = ((size - img.width) // 2, (size - img.height) // 2)
+    canvas.paste(img, offset, img)
+    return canvas
+
+
+def process_one(source: Path, target: Path, size: int, remove_fn, image_module) -> None:
+    if remove_fn is None:
+        with image_module.open(source) as src:
+            no_bg = src.convert("RGBA")
+    else:
+        no_bg = remove_background(source, remove_fn, image_module)
+    cropped = crop_by_alpha(no_bg)
+    squared = place_on_square(cropped, size, image_module)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    squared.save(target, format="PNG")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="批量处理老娘舅人物 PNG 立绘")
+    parser.add_argument("--raw-dir", default="assets/raw", help="原图目录")
+    parser.add_argument("--output-dir", default="assets/portraits", help="输出目录")
+    parser.add_argument("--size", type=int, default=768, help="输出方图边长")
+    parser.add_argument(
+        "--disable-rembg",
+        action="store_true",
+        help="禁用 rembg 抠图，仅做统一尺寸与 PNG 转换",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    raw_dir = Path(args.raw_dir)
+    output_dir = Path(args.output_dir)
+
+    if not raw_dir.exists():
+        print(f"原图目录不存在：{raw_dir}")
+        return 1
+
+    try:
+        image_module = load_pillow_image_module()
+    except ModuleNotFoundError:
+        print("[ERROR] 未安装 Pillow，请先安装：pip install pillow")
+        return 1
+
+    remove_fn = None
+    if not args.disable_rembg:
+        try:
+            remove_fn = load_rembg_remove()
+        except ModuleNotFoundError:
+            print("[WARN] 未安装 rembg，已自动降级为仅统一尺寸与 PNG 转换。")
+            print("[TIP] 如需自动抠图，请先安装：pip install rembg onnxruntime")
+
+    handled = 0
+    for character, source in iter_existing_sources(raw_dir):
+        target = output_dir / f"{character.slug}.png"
+        process_one(source, target, args.size, remove_fn, image_module)
+        handled += 1
+        print(f"[OK] {character.name}: {source.name} -> {target}")
+
+    print(f"处理完成：{handled} 张")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- 为项目添加一套可复用的素材预处理流程，便于将原始剧照批量转换为统一尺寸并（可选地）抠出透明背景的 PNG 立绘以供页面使用。 

### Description

- 新增脚本 `scripts/prepare_character_assets.py`，支持从 `assets/raw` 批量读取、可选使用 `rembg` 抠图、裁剪并置于方形画布后输出到 `assets/portraits`，并提供 `--size`、`--disable-rembg`、`--raw-dir` 与 `--output-dir` 等参数。 
- 新增 `assets/README.md`，包含角色清单、目录说明、处理命令与版权提示，并新增 `assets/source_log.csv` 用于记录素材来源。 
- 新增空目录占位文件 `assets/raw/.gitkeep` 和 `assets/portraits/.gitkeep` 以保留目录结构。 
- 更新顶级 `README.md`，增加素材预处理说明与示例命令 `python scripts/prepare_character_assets.py --size 768`，并说明脚本在缺失 `rembg` 时的降级行为。 

### Testing

- 未添加自动化测试，也未在 CI 中运行自动化测试。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69927a92c5bc83299b9c384fdcfededa)